### PR TITLE
Fix ShibuyaToken Initializer Validation

### DIFF
--- a/contracts/Shibuya.v1.sol
+++ b/contracts/Shibuya.v1.sol
@@ -24,6 +24,7 @@ contract ShibuyaToken is Initializable, ERC20Upgradeable, ERC20BurnableUpgradeab
         _disableInitializers();
     }
 
+    /// @custom:oz-upgrades-validate-as-initializer
     function initializeV2(address defaultAdmin) reinitializer(2) public {
         require(defaultAdmin != address(0), "Cannot set the default admin to zero address");
 

--- a/contracts/Shibuya.v2.sol
+++ b/contracts/Shibuya.v2.sol
@@ -28,6 +28,7 @@ contract ShibuyaToken is Initializable, ERC20Upgradeable, ERC20BurnableUpgradeab
         _disableInitializers();
     }
 
+    /// @custom:oz-upgrades-validate-as-initializer
     function initializeV3(address defaultAdmin) reinitializer(3) public {
         require(defaultAdmin != address(0), "Cannot set the default admin to zero address");
 

--- a/test/ShibuyaToken.ts
+++ b/test/ShibuyaToken.ts
@@ -43,8 +43,7 @@ describe("ShibuyaToken", function () {
         call: {
           fn: "initializeV2",
           args: [owner.address],
-        },
-        unsafeAllow: ["missing-initializer"],
+        }
       }
     );
 
@@ -58,8 +57,7 @@ describe("ShibuyaToken", function () {
         call: {
           fn: "initializeV3",
           args: [owner.address],
-        },
-        unsafeAllow: ["missing-initializer"],
+        }
       }
     );
 
@@ -353,10 +351,7 @@ describe("ShibuyaToken", function () {
       
       await upgrades.upgradeProxy(
         await shibuyaToken.getAddress(),
-        shibuyaTokenV2Factory,
-        {
-          unsafeAllow: ["missing-initializer"],
-        }
+        shibuyaTokenV2Factory
       );
   
       expect(await upgradedContract.getAddress()).to.equal(
@@ -377,10 +372,7 @@ describe("ShibuyaToken", function () {
       
       await upgrades.upgradeProxy(
         await shibuyaToken.getAddress(),
-        shibuyaTokenV2Factory,
-        {
-          unsafeAllow: ["missing-initializer"],
-        }
+        shibuyaTokenV2Factory
       );
       
       // Verify state is maintained
@@ -394,10 +386,7 @@ describe("ShibuyaToken", function () {
       await expect(
         upgrades.upgradeProxy(
           await shibuyaToken.getAddress(),
-          shibuyaTokenV2Factory.connect(user),
-          {
-            unsafeAllow: ["missing-initializer"],
-          }
+          shibuyaTokenV2Factory.connect(user)
         )
       ).to.be.revertedWith("Caller is not the owner");
     });
@@ -416,10 +405,7 @@ describe("ShibuyaToken", function () {
       
       await upgrades.upgradeProxy(
         await shibuyaToken.getAddress(),
-        shibuyaTokenV2Factory,
-        {
-          unsafeAllow: ["missing-initializer"],
-        }
+        shibuyaTokenV2Factory
       );
       
       // Check total supply after upgrade
@@ -443,10 +429,7 @@ describe("ShibuyaToken", function () {
       
       await upgrades.upgradeProxy(
         await shibuyaToken.getAddress(),
-        shibuyaTokenV2Factory,
-        {
-          unsafeAllow: ["missing-initializer"],
-        }
+        shibuyaTokenV2Factory
       );
       
       // Verify roles are maintained
@@ -468,10 +451,7 @@ describe("ShibuyaToken", function () {
       
       await upgrades.upgradeProxy(
         await shibuyaToken.getAddress(),
-        shibuyaTokenV2Factory,
-        {
-          unsafeAllow: ["missing-initializer"],
-        }
+        shibuyaTokenV2Factory
       );
       
       // Test mint functionality


### PR DESCRIPTION
**Pull Request Summary**

> Addresses the OpenZeppelin Upgrades plugin validation error for missing initializer tags in ShibuyaToken v1 and v2 contracts. Removes unnecessary 'unsafeAllow' flags from tests.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- N/A

**Fixes**

- Adds `@custom:oz-upgrades-validate-as-initializer` tag to `initializeV2` in `Shibuya.v1.sol` and `initializeV3` in `Shibuya.v2.sol`.

**Changes**

- Removes `unsafeAllow: ['missing-initializer']` from deployment/upgrade calls in `test/ShibuyaToken.ts`.

**To-dos**

- N/A