### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for this repository
+# These owners will be the default owners for everything in the repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @AstarNetwork/astar-core-dev 


### PR DESCRIPTION
**Pull Request Summary**

This PR adds a CODEOWNERS file to the repository that assigns the Astar core development team (@AstarNetwork/astar-core-dev) as the default owners for all files in the repository.

**Check list**

- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [x] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- Add CODEOWNERS file to set @AstarNetwork/astar-core-dev as the code owners

**Fixes**

- N/A

**Changes**

- N/A